### PR TITLE
fix: update react-native version to 0.76.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "expo-status-bar": "~2.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.8",
+    "react-native": "0.76.9",
     "react-native-calendars": "^1.1310.0",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",


### PR DESCRIPTION
This pull request includes a minor version update for the `react-native` dependency in the `package.json` file.

Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R20): Updated `react-native` from version `0.76.8` to `0.76.9`.